### PR TITLE
Add more Forth fileTypes.

### DIFF
--- a/Syntaxes/Forth.tmLanguage
+++ b/Syntaxes/Forth.tmLanguage
@@ -4,8 +4,13 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
+		<string>4th</string>
+		<string>f</string>
+		<string>forth</string>
+		<string>fr</string>
 		<string>frt</string>
 		<string>fs</string>
+		<string>fth</string>
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~F</string>


### PR DESCRIPTION
These are commonly used for Forth: `4th`, `f`, `fr`, and `fth`.  `forth` isn't that common, but it's an obvious 
marker for Forth files.

([These are all supported by GitHub.](https://github.com/github/linguist/blob/8e9c224952d72ae50504f7a0608d4663b29ba793/lib/linguist/languages.yml#L1268-L1276))

CC @vze26m98
